### PR TITLE
Fix Nix Build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
               cargoLock = {
                 lockFile = ./Cargo.lock;
                 outputHashes = {
-                  "ecolor-0.30.0" = "sha256-VDFyWZgbXJGc1Dkx765bSAifXKOLAxo91b4msTeCM5Q=";
+                  "ecolor-0.31.1" = "sha256-Tvm9zAxTX5VjFtTAnj9ZNNqJ8YGyTUAG5ZfkQY1rd1c=";
                 };
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           bzip2
           fontconfig
           openssl
+          wayland
         ];
         libraryPath = "/run/opengl-driver/lib:${pkgs.lib.makeLibraryPath libs}";
       in


### PR DESCRIPTION
Fixes #8

Problem from the issue itself was a outdated library, the program is using 31.1 now, not 30.0 anymore.

The additional thing in the bottom was about a runtime dependency missing on Wayland systems. I added that as well.

I can confirm that with both those fixes the program builds and runs nicely again.

Thanks for making this program, so glad i dont have to use ancient ugly slipstream anymore.