### PR TITLE
Fix panic when calling mod.util.eval in XML sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `mod.meta.current_path` and `mod.util.eval()` causing a panic when used in the XML Sandbox.
+
 ## [v0.7.2]
 
 ### Added

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -236,11 +236,9 @@ impl ModLuaRuntime {
             )?;
         }
 
-        if let Some(path) = meta_path {
-            lua.set_app_data(LuaExecutionContext {
-                current_file: Some(path.into()),
-            });
-        }
+        lua.set_app_data(LuaExecutionContext {
+            current_file: meta_path.map(Box::from),
+        });
 
         lua.load(code)
             .set_name(chunk_name)


### PR DESCRIPTION
Calling `mod.util.eval` causes a panic when called in the XML sandbox due to the `Lua` runtime not having a `LuaExecutionContext` set for it, which is not supposed to be possible (use of `expect` in `Lua::execution_context`). This is due to `ModLuaRuntime` not setting the execution context at all when provided with a `meta_path` that is `None`, instead of setting the execution context to a `LuaExecutionContext` with its `current_file` field set to `None` like it was presumably meant to. This PR fixes this problem and ensures that the execution context will be set in all cases.