### PR TITLE
Improve error message for extract command failing to open output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Fixed `mod.meta.current_path` and `mod.util.eval()` causing a panic when used in the XML Sandbox.
+- Improved error message for `extract` command failing extract an output file (now mentions path).
 
 ## [v0.7.2]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -502,7 +502,11 @@ pub fn main(command: Command) -> Result<()> {
                     Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
                     other => other.context("Failed to create output directory")?,
                 }
-                std::io::copy(&mut pkg.open(&path)?, &mut File::create(out)?)?;
+                std::io::copy(
+                    &mut pkg.open(&path)?,
+                    &mut File::create(out).with_context(|| format!("Failed to create {path} in output directory"))?,
+                )
+                .with_context(|| format!("Failed to extract {path}"))?;
             }
             Ok(())
         }


### PR DESCRIPTION
I created a scenario where this fails by breaking the patcher so it probably doesn't happen in the real world, still better if error is less not cryptic.