### PR TITLE
Support size ranges in version index

### DIFF
--- a/src/hyperspace/installer/versions.rs
+++ b/src/hyperspace/installer/versions.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{Read, Seek},
+    ops::Range,
     sync::Arc,
     time::Duration,
 };
@@ -111,6 +112,7 @@ impl Patch {
 #[derive(Deserialize)]
 pub struct Version {
     pub(super) exe_size: u64,
+    pub(super) exe_size_range: Option<Range<u64>>,
     platform: super::Platform,
     #[serde(default)]
     natively_supported: bool,
@@ -152,7 +154,16 @@ pub struct VersionIndex {
 
 impl VersionIndex {
     pub fn by_exe_size(&self, size: u64) -> Option<Arc<Version>> {
-        self.versions.iter().find(|version| version.exe_size == size).cloned()
+        self.versions
+            .iter()
+            .find(|version| {
+                version.exe_size == size
+                    || version
+                        .exe_size_range
+                        .as_ref()
+                        .is_some_and(|range| range.contains(&size))
+            })
+            .cloned()
     }
 
     fn load(body: &str) -> Result<Arc<Self>> {

--- a/src/hyperspace/installer/versions.rs
+++ b/src/hyperspace/installer/versions.rs
@@ -206,7 +206,7 @@ impl VersionIndex {
                         .into())
                 })?,
             )
-            .context("Failed to decode fetched or cached versions.xml")?,
+            .context("Failed to decode fetched or cached versions.json")?,
         )
     }
 
@@ -217,7 +217,7 @@ impl VersionIndex {
         };
 
         Ok(Some(Self::load(
-            &String::from_utf8(body).context("Failed to decode fetched or cached versions.xml")?,
+            &String::from_utf8(body).context("Failed to decode fetched or cached versions.json")?,
         )?))
     }
 }


### PR DESCRIPTION
MacOS code signing can result in differently-sized executables so add support for ranges to handle that.

Currently after installing Hyperspace on MacOS a common scenario is that ftlman just stops recognizing the installation (but it is installed correctly and works if you ignore the warnings).